### PR TITLE
Add mobile controls to SignalSlayer (#9)

### DIFF
--- a/public/src/games/SignalSlayer.js
+++ b/public/src/games/SignalSlayer.js
@@ -1,6 +1,7 @@
 import { correctSignals, correctSignalsTest, USE_TEST_SIGNALS } from '../data/correctSignals.js';
 import { generateDistractors } from '../data/distractors.js';
 import { injectNavButtons, palette } from '../shared.js';
+import { nextTrack } from './signalSlayerLogic.js';
 
 const SignalSlayer = {
   start(line, user, { onWin, onLose }) {
@@ -166,7 +167,7 @@ const SignalSlayer = {
         outlinedText(gameWon ? 'Congratulations!' : 'Game Over!', centerX, centerY,
           '700 40px "Pixelify Sans", sans-serif', gameWon ? pal.gold : pal.red);
         if (!gameWon) {
-          outlinedText('Press Enter to retry', centerX, centerY + 44,
+          outlinedText('Tap or press Enter to retry', centerX, centerY + 44,
             '700 18px "Pixelify Sans", sans-serif', pal.creamOnDark);
         }
         ctx.restore();
@@ -179,18 +180,64 @@ const SignalSlayer = {
         requestAnimationFrame(gameLoop);
       }
     }
-    window.addEventListener('keydown', e => {
-      if (gameOver && !gameWon && (e.code === 'Enter' || e.code === 'NumpadEnter' || e.code === 'Space')) {
+    // Shared controls, used by keyboard, on-screen buttons and canvas taps so
+    // the game is playable on a touchscreen with no physical keyboard.
+    function move(direction) {
+      if (gameOver) return;
+      playerTrack = nextTrack(playerTrack, direction, TRACKS);
+    }
+    // On game over (other than a win) any input restarts the round. On desktop
+    // that's Enter/Space; on mobile it's a tap, since there is no Enter key.
+    function tryRetry() {
+      if (gameOver && !gameWon) {
         resetGame();
         gameLoop();
-        return;
+        return true;
       }
-      if (e.code === 'ArrowLeft' && playerTrack > 0) {
-        playerTrack--;
-      } else if (e.code === 'ArrowRight' && playerTrack < TRACKS - 1) {
-        playerTrack++;
+      return false;
+    }
+    window.addEventListener('keydown', e => {
+      if (e.code === 'Enter' || e.code === 'NumpadEnter' || e.code === 'Space') {
+        if (tryRetry()) return;
+      }
+      if (e.code === 'ArrowLeft') {
+        move(-1);
+      } else if (e.code === 'ArrowRight') {
+        move(1);
       }
     });
+    // Tap the left/right half of the canvas to steer; tap to retry when over.
+    function handleCanvasTap(clientX) {
+      if (tryRetry()) return;
+      const rect = canvas.getBoundingClientRect();
+      const x = clientX - rect.left;
+      move(x < rect.width / 2 ? -1 : 1);
+    }
+    canvas.addEventListener('click', e => handleCanvasTap(e.clientX));
+    canvas.addEventListener('touchstart', e => {
+      e.preventDefault();
+      handleCanvasTap(e.touches[0].clientX);
+    }, { passive: false });
+    // On-screen ◀ / ▶ buttons: the primary control on mobile, harmless on desktop.
+    const controls = document.createElement('div');
+    controls.className = 'ss-controls';
+    function makeControlBtn(label, ariaLabel, direction) {
+      const btn = document.createElement('button');
+      btn.className = 'tg-btn ss-control-btn';
+      btn.type = 'button';
+      btn.textContent = label;
+      btn.setAttribute('aria-label', ariaLabel);
+      // Use pointerdown so it responds immediately to a tap and never steals
+      // focus away from the game; prevent the synthetic click/scroll.
+      btn.addEventListener('pointerdown', e => {
+        e.preventDefault();
+        if (!tryRetry()) move(direction);
+      });
+      return btn;
+    }
+    controls.appendChild(makeControlBtn('◀', 'Move left', -1));
+    controls.appendChild(makeControlBtn('▶', 'Move right', 1));
+    app.appendChild(controls);
     // Start game
     resetGame();
     setTimeout(() => {

--- a/public/src/games/signalSlayerLogic.js
+++ b/public/src/games/signalSlayerLogic.js
@@ -1,0 +1,17 @@
+// Pure movement helpers for SignalSlayer, kept separate from the DOM/canvas
+// code so they can be unit-tested. The train sits on one of `tracks` lanes
+// (0-indexed). Moving never wraps around or runs off the ends.
+
+/**
+ * Compute the track the train should be on after a move.
+ * @param {number} current  current track index (0..tracks-1)
+ * @param {-1|1} direction   -1 = left, 1 = right
+ * @param {number} tracks    total number of tracks
+ * @returns {number} the clamped new track index
+ */
+export function nextTrack(current, direction, tracks) {
+  const target = current + direction;
+  if (target < 0) return 0;
+  if (target > tracks - 1) return tracks - 1;
+  return target;
+}

--- a/public/styles.css
+++ b/public/styles.css
@@ -466,6 +466,26 @@ body::after {
 }
 
 /* ============================================================
+   SignalSlayer — on-screen left/right controls for touch devices.
+   ============================================================ */
+.ss-controls {
+  display: flex;
+  justify-content: center;
+  gap: var(--space-5);
+  margin: var(--space-2) auto var(--space-5);
+}
+.ss-control-btn {
+  width: 96px;
+  height: 72px;
+  font-size: var(--text-2xl, 2rem);
+  line-height: 1;
+  /* Big, finger-friendly tap targets; don't let a long-press select the glyph. */
+  touch-action: manipulation;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+/* ============================================================
    SchemaPro — cream card with a clickable SVG schematic.
    ============================================================ */
 .schemapro-container {

--- a/server/test/signalSlayerLogic.test.js
+++ b/server/test/signalSlayerLogic.test.js
@@ -1,0 +1,33 @@
+// Tests for SignalSlayer's pure track-movement helper. These guard the rule
+// that drives both the keyboard arrows and the new on-screen mobile controls:
+// the train moves one lane at a time and never runs off either end.
+
+import { describe, it, expect } from 'vitest';
+import { nextTrack } from '../../public/src/games/signalSlayerLogic.js';
+
+const TRACKS = 3;
+
+describe('nextTrack', () => {
+  it('moves right one lane', () => {
+    expect(nextTrack(0, 1, TRACKS)).toBe(1);
+    expect(nextTrack(1, 1, TRACKS)).toBe(2);
+  });
+
+  it('moves left one lane', () => {
+    expect(nextTrack(2, -1, TRACKS)).toBe(1);
+    expect(nextTrack(1, -1, TRACKS)).toBe(0);
+  });
+
+  it('clamps at the left edge (no wrap)', () => {
+    expect(nextTrack(0, -1, TRACKS)).toBe(0);
+  });
+
+  it('clamps at the right edge (no wrap)', () => {
+    expect(nextTrack(TRACKS - 1, 1, TRACKS)).toBe(TRACKS - 1);
+  });
+
+  it('works for an arbitrary track count', () => {
+    expect(nextTrack(3, 1, 5)).toBe(4);
+    expect(nextTrack(4, 1, 5)).toBe(4);
+  });
+});


### PR DESCRIPTION
Closes #9.

## Problem
SignalSlayer could only be steered with the keyboard arrow keys, so on a phone/tablet there was no way to move the train between tracks — the game was unplayable on mobile.

## Changes
- **On-screen ◀ / ▶ buttons** below the canvas — the primary mobile control (big 96×72 tap targets; also work with a mouse on desktop).
- **Tap the left/right half of the canvas** to steer the train.
- **Tap to retry on game over** — previously "Press Enter to retry", which is impossible on mobile. Hint now reads "Tap or press Enter to retry".
- Extracted the track-movement math into a pure, unit-tested `nextTrack` helper (`signalSlayerLogic.js`) shared by the keyboard, button, and tap handlers.

## Testing
- Added `server/test/signalSlayerLogic.test.js` (5 tests) covering move/clamp/no-wrap. Full suite: **40 passed**.
- Verified in a real browser (Playwright): ▶ moves the train right, ◀ moves it left, and pressing past the edge does not wrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)