### PR TITLE
Prevent double-tap zoom on buttons in RememberBee (#16)

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -11,6 +11,10 @@
 
 *, *::before, *::after { box-sizing: border-box; }
 
+/* Stop mobile browsers from treating fast button taps as a double-tap-to-zoom
+   gesture (e.g. the RememberBee keypad). Normal pinch-zoom still works. */
+button { touch-action: manipulation; }
+
 body {
   font-family: var(--font-base);
   color: var(--cream-on-dark);


### PR DESCRIPTION
Closes #16.

## Problem
Tapping the RememberBee number keypad quickly fired the mobile browser's **double-tap-to-zoom** gesture, so the screen zoomed in during play.

## Fix
Added `touch-action: manipulation` to all `button`s. This tells the browser there's no double-tap gesture to wait for, so rapid taps register as taps instead of a zoom. Applied globally (not just the keypad) so the other games' buttons get the same treatment. Pinch-to-zoom still works, so accessibility is preserved.

## Testing
- Verified in a real browser: all 11 keypad buttons (and nav buttons) now compute `touch-action: manipulation`.
- Tested by the user on their machine and a phone over the home network — no more zoom on rapid taps.
- Full test suite: **40 passing** (no logic changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)